### PR TITLE
Improve work distribution.

### DIFF
--- a/pytest_split_tests/__init__.py
+++ b/pytest_split_tests/__init__.py
@@ -9,9 +9,8 @@ import pytest
 
 def get_group_size(total_items, total_groups, group_id):
     """Return the group size."""
-    rem = total_items % total_groups
-    base = (total_items - rem) // total_groups
-    return base + 1 if group_id <= rem else base
+    base = total_items // total_groups
+    return base + 1 if group_id <= total_items % total_groups else base
 
 
 def get_group(items, group_size, group_id):

--- a/pytest_split_tests/__init__.py
+++ b/pytest_split_tests/__init__.py
@@ -7,18 +7,17 @@ from _pytest.config import create_terminal_writer
 import pytest
 
 
-def get_group_size(total_items, total_groups):
+def get_group_size(total_items, total_groups, group_id):
     """Return the group size."""
-    return int(math.ceil(float(total_items) / total_groups))
+    rem = total_items % total_groups
+    base = (total_items - rem) // total_groups
+    return base + 1 if group_id <= rem else base
 
 
 def get_group(items, group_size, group_id):
     """Get the items from the passed in group based on group size."""
     start = group_size * (group_id - 1)
     end = start + group_size
-
-    if start >= len(items) or start < 0:
-        raise ValueError("Invalid test-group argument")
 
     return items[start:end]
 
@@ -45,6 +44,9 @@ def pytest_collection_modifyitems(session, config, items):
 
     if not group_count or not group_id:
         return
+
+    if not 0 < group_id <= group_count:
+        raise ValueError("Invalid test-group argument")
 
     test_dict = {item.name: item for item in items}
     original_order = {item: index for index, item in enumerate(items)}
@@ -76,7 +78,7 @@ def pytest_collection_modifyitems(session, config, items):
 
     total_unscheduled_items = len(unscheduled_tests)
 
-    group_size = get_group_size(total_unscheduled_items, group_count)
+    group_size = get_group_size(total_unscheduled_items, group_count, group_id)
     tests_in_group = get_group(unscheduled_tests, group_size, group_id)
     items[:] = tests_in_group + prescheduled_tests
 


### PR DESCRIPTION
When you have, say, 25 tests and 8 groups, the current work distribution formula will determine the group size at 4 and then the first 6 groups will be assigned 4 tests each, the 7th will get 1 and the 8th will get 0. This is bad first because it's not as uniform as it could be and second because group 8 will throw an exception (at line 21).

I replaced the formula to fix these issues. Now, all groups get to run at least `items // groups` tests, and the first `items % groups` groups will receive an extra one. Therefore, the difference between the number of items assigned to any two group will be at most 1. Also, groups with 0 assigned items no longer raise an exception.