### PR TITLE
Fixed option defaults

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 The MIT License (MIT)
 
+Copyright (c) 2021 Tyler Krehbiel
 Copyright (c) 2019 Eric Ahn
 Copyright (c) 2016 Mark Adams
 

--- a/pytest_split_tests/__init__.py
+++ b/pytest_split_tests/__init__.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-from random import Random
 import json
 import math
+from random import Random
 
 from _pytest.config import create_terminal_writer
+
 import pytest
 
 

--- a/pytest_split_tests/__init__.py
+++ b/pytest_split_tests/__init__.py
@@ -29,9 +29,9 @@ def pytest_addoption(parser):
                     help='The number of groups to split the tests into')
     group.addoption('--test-group', dest='test-group', type=int,
                     help='The group of tests that should be executed')
-    group.addoption('--test-group-random-seed', dest='random-seed', type=int,
+    group.addoption('--test-group-random-seed', dest='random-seed', type=int, default=False,
                     help='Integer to seed pseudo-random test selection')
-    group.addoption('--test-group-prescheduled', dest='prescheduled', type=str,
+    group.addoption('--test-group-prescheduled', dest='prescheduled', type=str, default=None,
                     help='Path to JSON file containing which tests to run.')
 
 
@@ -40,8 +40,8 @@ def pytest_collection_modifyitems(session, config, items):
     yield
     group_count = config.getoption('test-group-count')
     group_id = config.getoption('test-group')
-    seed = config.getoption('random-seed', False)
-    prescheduled_path = config.getoption('prescheduled', None)
+    seed = config.getoption('random-seed')
+    prescheduled_path = config.getoption('prescheduled')
 
     if not group_count or not group_id:
         return

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -1,3 +1,5 @@
+import pytest
+
 pytest_plugins = ['pytester']
 
 
@@ -21,7 +23,8 @@ def test_group_runs_appropriate_tests(testdir):
     ])
 
 
-def test_group_runs_all_test(testdir):
+@pytest.mark.parametrize("random_seed_args", [[], ["--test-group-random-seed", "5"]])
+def test_group_runs_all_test(testdir, random_seed_args):
     """Given a large set of tests executed with a random seed, assert that all
     tests are executed exactly once.
     """
@@ -55,19 +58,19 @@ def test_group_runs_all_test(testdir):
 
     result = testdir.inline_run('--test-group-count', '2',
                                 '--test-group', '1',
-                                '--test-group-random-seed', '5')
+                                *random_seed_args)
     group_1 = [x.item.name for x in result.calls if x._name == 'pytest_runtest_call']
     result.assertoutcome(passed=13)
 
     result = testdir.inline_run('--test-group-count', '2',
                                 '--test-group', '2',
-                                '--test-group-random-seed', '5')
+                                *random_seed_args)
     group_2 = [x.item.name for x in result.calls if x._name == 'pytest_runtest_call']
     result.assertoutcome(passed=12)
 
     result = testdir.inline_run('--test-group-count', '1',
                                 '--test-group', '1',
-                                '--test-group-random-seed', '5')
+                                *random_seed_args)
     all_tests = [x.item.name for x in result.calls if x._name == 'pytest_runtest_call']
 
     assert set(group_1 + group_2) == set(all_tests)


### PR DESCRIPTION
# Justification
`config.getoption('random-seed', False)` returned `None` instead of `False` if **--test-group-random-seed** was not specified on the command line. According to the docs for [getoption](https://docs.pytest.org/en/6.2.x/reference.html#pytest.config.Config.getoption), the **default** parameter specifies the default value if no option of that name exists. Since the option is name does exist, the default on **getoption** was never applied.

# Implementation
- Moved option defaults from **getoption** to **addoption**.
- Extended **test_group_runs_all_test** to test without **--test-group-random-seed** set
- Fixed flake8 errors in \_\_init\_\_.py
- Update LICENSE

# Testing
Ran tox
```
  ...
  py27: commands succeeded
  py35: commands succeeded
  py36: commands succeeded
  py37: commands succeeded
  flake8: commands succeeded
  congratulations :)
```